### PR TITLE
Move grading to branch and update modal/grading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ export const App = () => {
           <Route path="admin/applications/:applicationId" element={<ApplicationDetailPage />} />
           <Route path="admin/statistics" element={<Statistics />} />
           <Route path="grading" element={<GradingDashboard />} />
-          <Route path="grading/question" element={<GradeQuestion />} />
+          <Route path="grading/:gradingGroup/question" element={<GradeQuestion />} />
           <Route path="grading/leaderboard" element={<Leaderboard />} />
         </Route>
       </Routes>

--- a/src/components/admin/branchSettings/BranchCard.tsx
+++ b/src/components/admin/branchSettings/BranchCard.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, Tag, Stack, Button, Container } from "@chakra-ui/react";
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import _ from "lodash";
 
 import { Branch } from "./BranchSettings";
 import { parseDateString } from "../../../util/util";
@@ -25,8 +26,14 @@ const BranchCard: React.FC<Props> = props => {
         <Stack>
           <Stack spacing="1">
             <Text fontSize="sm" color="muted">
-              <Tag mr="8px">{props.branch.type}</Tag>
-              {props.branch.applicationGroup && <Tag>{props.branch.applicationGroup}</Tag>}
+              {props.branch.grading?.enabled && (
+                <Tag mr="8px" colorScheme="orange">
+                  Grading Enabled
+                </Tag>
+              )}
+              {props.branch.applicationGroup && (
+                <Tag>{_.capitalize(props.branch.applicationGroup)}</Tag>
+              )}
             </Text>
             <Text fontSize="lg" fontWeight="medium">
               {props.branch.name}

--- a/src/components/admin/branchSettings/BranchSettings.tsx
+++ b/src/components/admin/branchSettings/BranchSettings.tsx
@@ -37,6 +37,10 @@ export interface Branch {
     jsonSchema: string;
     uiSchema: string;
   }[];
+  grading?: {
+    enabled: boolean;
+    group?: string;
+  };
 }
 
 const BranchSettings: React.FC = () => {

--- a/src/components/admin/grading/GradingDashboard.tsx
+++ b/src/components/admin/grading/GradingDashboard.tsx
@@ -1,76 +1,79 @@
 import React from "react";
-import { Box, Heading, Stack, Text } from "@chakra-ui/react";
+import { Box, Button, Heading, Stack, Text } from "@chakra-ui/react";
 import { Link, useParams } from "react-router-dom";
 
 const GradingDashboardCard: React.FC<{
-  title: string,
-  description: string,
-  endpoint: string
-}> = (props) => (
+  title: string;
+  description: string;
+  buttons: JSX.Element;
+}> = props => (
   <Box
-    width={{"base": "100%", "md": "50%"}}
+    borderRadius="5px"
+    textAlign="center"
+    boxShadow="rgba(0, 0, 0, 0.15) 0px 0px 6px 1px"
+    padding="30px"
   >
-    <Link to={props.endpoint}>
-      <Box
-        borderRadius="5px"
-        textAlign="center"
-        boxShadow="rgba(0, 0, 0, 0.15) 0px 0px 6px 1px"
-        _hover={{
-          boxShadow: "rgba(0, 0, 0, 0.20) 0px 0px 8px 2px",
-          color: "white",
-          bg: "#7b69ec"
-        }}
-        transition="background 0.25s ease-in-out"
-        paddingX="48px"
-        paddingY="40px"
-      >
-        <Heading fontSize="20px" fontWeight="semibold" marginBottom="5px">
-          {props.title}
-        </Heading>
-        <Text>
-          {props.description}
-        </Text>
-      </Box>
-    </Link>
+    <Heading fontSize="20px" fontWeight="semibold" marginBottom="5px">
+      {props.title}
+    </Heading>
+    <Text mb="3">{props.description}</Text>
+    <Stack direction={{ base: "column", lg: "row" }} flexGrow="1">
+      {props.buttons}
+    </Stack>
   </Box>
-)
+);
 
 const GradingDashboard: React.FC = () => {
   const { hexathonId } = useParams();
   const options = [
     {
       title: "Grade a Question",
-      description: "Score a random applicant's question and score their answer based on the provided rubric!",
-      endpoint: `/${hexathonId}/grading/question`
+      description:
+        "Score a random applicant's question and score their answer based on the provided rubric!",
+      endpoint: `/${hexathonId}/grading/question`,
+      buttons: (
+        <>
+          <Link to="generalGroup/question" style={{ width: "100%" }}>
+            <Button w="100%">General Group</Button>
+          </Link>
+          <Link to="emergingGroup/question" style={{ width: "100%" }}>
+            <Button w="100%">Emerging Group</Button>
+          </Link>
+        </>
+      ),
     },
     {
       title: "Leaderboard",
-      description: "See how you rank compared to other graders! Grade more applications to climb the leaderboard!",
-      endpoint: `/${hexathonId}/grading/leaderboard`
-    }
-  ]
+      description:
+        "See how you rank compared to other graders! Grade more applications to climb the leaderboard!",
+      endpoint: `/${hexathonId}/grading/leaderboard`,
+      buttons: (
+        <Link to="leaderboard" style={{ width: "100%" }}>
+          <Button w="100%">View Leaderboard</Button>
+        </Link>
+      ),
+    },
+  ];
 
   return (
     <Stack
       margin="auto"
       paddingY="30px"
-      width={{"base": "80%", "md": "65%"}}
-      direction={{"base": "column", "md": "row"}}
+      width={{ base: "90%", md: "75%" }}
+      direction={{ base: "column", md: "row" }}
       spacing="20px"
       alignContent="center"
     >
-      {
-        options.map((option) => (
-          <GradingDashboardCard
-            key={option.title}
-            title={option.title}
-            description={option.description}
-            endpoint={option.endpoint}
-          />
-        ))
-      }
+      {options.map(option => (
+        <GradingDashboardCard
+          key={option.title}
+          title={option.title}
+          description={option.description}
+          buttons={option.buttons}
+        />
+      ))}
     </Stack>
   );
-}
+};
 
 export default GradingDashboard;

--- a/src/components/branchEditor/FormPageModal.tsx
+++ b/src/components/branchEditor/FormPageModal.tsx
@@ -15,7 +15,7 @@ import {
 import React, { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import axios from "axios";
-import { apiUrl, Service } from "@hex-labs/core";
+import { apiUrl, handleAxiosError, Service } from "@hex-labs/core";
 
 import { AxiosRefetch } from "../../util/types";
 
@@ -92,14 +92,7 @@ const FormPageModal: React.FC<Props> = props => {
       }
       await props.refetch();
     } catch (e: any) {
-      console.log(e);
-      toast({
-        title: "Error!",
-        description: "One or more entries are invalid. Please try again.",
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
+      handleAxiosError(e);
     } finally {
       props.onClose();
     }


### PR DESCRIPTION
I made it easier for people to pick which group they'll be grading for. This allows the user to update their grading group and updates the form modal to allow us to update the branch.

This corresponds with the associated backend changes here: https://github.com/HackGT/api/pull/90

New grading view allowing a user to pick
<img width="1512" alt="Screen Shot 2022-09-07 at 2 40 43 AM" src="https://user-images.githubusercontent.com/8273038/188806952-e7849316-38ea-4719-bb6b-21935a0c4665.png">

Branch settings pages shows which branches are enabled for grading
<img width="892" alt="Screen Shot 2022-09-07 at 2 41 04 AM" src="https://user-images.githubusercontent.com/8273038/188807026-2e0198ac-247e-468d-bdd5-f4363a9b3f34.png">
